### PR TITLE
Add grading primitives and manifest-driven pipeline

### DIFF
--- a/src/adjustments.py
+++ b/src/adjustments.py
@@ -15,7 +15,7 @@ def _ensure_rgb(image: Image.Image) -> Image.Image:
         return image.copy()
 
     if image.mode == "RGBA":
-        return image.convert("RGBA")
+        return image.copy()
 
     return image.convert("RGB")
 

--- a/src/adjustments.py
+++ b/src/adjustments.py
@@ -142,7 +142,7 @@ def apply_grading(image: Image.Image, grading: Optional[Dict[str, float]]) -> Im
     if highlight_lift:
         result = apply_highlight_lift(result, highlight_lift)
 
-    micro_contrast = grading.get("micro_contrast") or grading.get("local_contrast")
+    micro_contrast = grading.get("micro_contrast") if grading.get("micro_contrast") is not None else grading.get("local_contrast")
     if micro_contrast is not None:
         result = apply_local_contrast(result, micro_contrast)
 

--- a/src/adjustments.py
+++ b/src/adjustments.py
@@ -1,0 +1,149 @@
+"""Image grading helpers for the rendering pipeline."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import numpy as np
+from PIL import Image, ImageFilter
+
+
+def _ensure_rgb(image: Image.Image) -> Image.Image:
+    """Return a copy of *image* in RGB mode, preserving alpha if present."""
+
+    if image.mode == "RGB":
+        return image.copy()
+
+    if image.mode == "RGBA":
+        return image.convert("RGBA")
+
+    return image.convert("RGB")
+
+
+def _split_alpha(image: Image.Image):
+    if image.mode == "RGBA":
+        rgb, alpha = image.convert("RGBA"), image.getchannel("A")
+        return rgb.convert("RGB"), alpha
+    return _ensure_rgb(image), None
+
+
+def _recombine_alpha(rgb: Image.Image, alpha: Optional[Image.Image], original_mode: str) -> Image.Image:
+    if alpha is None:
+        if original_mode == "RGB":
+            return rgb
+        return rgb.convert(original_mode)
+
+    merged = rgb.convert("RGBA")
+    merged.putalpha(alpha)
+    if original_mode == "RGBA":
+        return merged
+    return merged.convert(original_mode)
+
+
+def apply_temperature_shift(image: Image.Image, mired_shift: float) -> Image.Image:
+    """Warm (+) or cool (-) an image by adjusting channel gains."""
+
+    if not mired_shift:
+        return image.copy()
+
+    base_rgb, alpha = _split_alpha(image)
+    arr = np.asarray(base_rgb).astype(np.float32)
+
+    gain = 1.0 + (mired_shift / 100.0)
+    gain = max(0.1, min(10.0, gain))
+
+    red_gain = gain
+    blue_gain = 1.0 / gain
+
+    gains = np.array([red_gain, 1.0, blue_gain], dtype=np.float32)
+    arr *= gains
+    np.clip(arr, 0.0, 255.0, out=arr)
+
+    warmed = Image.fromarray(arr.astype(np.uint8), mode="RGB")
+    return _recombine_alpha(warmed, alpha, image.mode)
+
+
+def apply_shadow_lift(image: Image.Image, amount: float) -> Image.Image:
+    """Lift the shadows by mixing dark pixels toward mid-tones."""
+
+    if not amount:
+        return image.copy()
+
+    amount = max(0.0, min(1.0, float(amount)))
+
+    base_rgb, alpha = _split_alpha(image)
+    arr = np.asarray(base_rgb).astype(np.float32) / 255.0
+
+    shadow_mask = 1.0 - np.clip(arr / 0.5, 0.0, 1.0)
+    lifted = arr + amount * shadow_mask
+    lifted = np.clip(lifted, 0.0, 1.0)
+
+    result = Image.fromarray((lifted * 255.0).astype(np.uint8), mode="RGB")
+    return _recombine_alpha(result, alpha, image.mode)
+
+
+def apply_highlight_lift(image: Image.Image, amount: float) -> Image.Image:
+    """Lift highlights toward white without blowing them out."""
+
+    if not amount:
+        return image.copy()
+
+    amount = max(0.0, min(1.0, float(amount)))
+
+    base_rgb, alpha = _split_alpha(image)
+    arr = np.asarray(base_rgb).astype(np.float32) / 255.0
+
+    highlight_mask = np.clip((arr - 0.5) / 0.5, 0.0, 1.0)
+    lifted = arr + amount * highlight_mask * (1.0 - arr)
+    lifted = np.clip(lifted, 0.0, 1.0)
+
+    result = Image.fromarray((lifted * 255.0).astype(np.uint8), mode="RGB")
+    return _recombine_alpha(result, alpha, image.mode)
+
+
+def apply_local_contrast(image: Image.Image, amount: float, radius: float = 2.0) -> Image.Image:
+    """Adjust local contrast using an unsharp mask style enhancement."""
+
+    if amount is None or amount == 1.0:
+        return image.copy()
+
+    amount = float(amount)
+    base = image.copy()
+
+    if amount > 1.0:
+        percent = min(500, max(0, int((amount - 1.0) * 200)))
+        if percent == 0:
+            return base
+        return base.filter(ImageFilter.UnsharpMask(radius=radius, percent=percent, threshold=0))
+
+    # Reduce local contrast by blending with a blurred version.
+    blend_factor = max(0.0, min(1.0, 1.0 - amount))
+    blurred = base.filter(ImageFilter.GaussianBlur(radius=radius))
+    return Image.blend(base, blurred, blend_factor)
+
+
+def apply_grading(image: Image.Image, grading: Optional[Dict[str, float]]) -> Image.Image:
+    """Apply grading primitives in a predictable order."""
+
+    if not grading:
+        return image.copy()
+
+    result = image.copy()
+
+    temp_shift = grading.get("temperature_shift")
+    if temp_shift:
+        result = apply_temperature_shift(result, temp_shift)
+
+    shadow_lift = grading.get("shadow_lift")
+    if shadow_lift:
+        result = apply_shadow_lift(result, shadow_lift)
+
+    highlight_lift = grading.get("highlight_lift")
+    if highlight_lift:
+        result = apply_highlight_lift(result, highlight_lift)
+
+    micro_contrast = grading.get("micro_contrast") or grading.get("local_contrast")
+    if micro_contrast is not None:
+        result = apply_local_contrast(result, micro_contrast)
+
+    return result

--- a/src/main.py
+++ b/src/main.py
@@ -4,9 +4,11 @@ Iterates through images in the input directory, applies processing,
 and saves results to the output directory.
 """
 
+import json
 import os
 import sys
 from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
 
 # Add src directory to path so we can import our modules
 sys.path.append(os.path.join(os.path.dirname(__file__)))
@@ -35,8 +37,175 @@ def get_image_files(directory):
     for file in os.listdir(directory):
         if any(file.lower().endswith(ext) for ext in image_extensions):
             image_files.append(os.path.join(directory, file))
-    
+
     return sorted(image_files)
+
+
+def _parse_mired_value(value) -> Optional[float]:
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, str):
+        clean = value.strip().lower()
+        if clean.endswith("_mireds"):
+            clean = clean[: -len("_mireds")]
+        try:
+            return float(clean)
+        except ValueError:
+            return None
+
+    return None
+
+
+def _parse_crop(entry: Dict) -> Optional[Tuple[int, int, int, int]]:
+    crop = entry.get("crop") or entry.get("crop_box")
+    if crop is None:
+        return None
+
+    if isinstance(crop, dict):
+        keys = ["left", "top", "right", "bottom"]
+        if all(k in crop for k in keys):
+            return tuple(int(crop[k]) for k in keys)
+        return None
+
+    if isinstance(crop, (list, tuple)) and len(crop) == 4:
+        return tuple(int(v) for v in crop)
+
+    return None
+
+
+def _extract_grading(entry: Dict) -> Dict[str, float]:
+    grading = {}
+    source = {}
+    if isinstance(entry.get("grading"), dict):
+        source.update(entry["grading"])
+    source.update({k: entry[k] for k in entry if k not in {"file", "input", "output", "crop", "crop_box", "grading"}})
+
+    temp_value = source.get("temperature_shift") or source.get("warm_shift")
+    temp_shift = _parse_mired_value(temp_value)
+    if temp_shift is not None and temp_shift != 0:
+        grading["temperature_shift"] = temp_shift
+
+    for key in ("shadow_lift", "highlight_lift", "micro_contrast", "local_contrast"):
+        value = source.get(key)
+        if value is None:
+            continue
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            continue
+        if key in ("micro_contrast", "local_contrast"):
+            grading["micro_contrast"] = numeric
+        else:
+            grading[key] = numeric
+
+    return grading
+
+
+def load_manifest(manifest_path: Path) -> List[Dict]:
+    if not manifest_path or not manifest_path.exists():
+        return []
+
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    if isinstance(data, dict):
+        images = data.get("images", [])
+    elif isinstance(data, list):
+        images = data
+    else:
+        images = []
+
+    valid_entries = []
+    for entry in images:
+        if not isinstance(entry, dict):
+            continue
+        if any(k in entry for k in ("file", "input")):
+            valid_entries.append(entry)
+
+    return valid_entries
+
+
+def build_jobs(
+    input_dir: Path,
+    output_dir: Path,
+    target_size: Tuple[int, int],
+    manifest_entries: Iterable[Dict],
+):
+    input_files = get_image_files(str(input_dir))
+    manifest_map: Dict[str, Dict] = {}
+
+    for entry in manifest_entries:
+        key = entry.get("file") or entry.get("input")
+        if key:
+            manifest_map[os.path.basename(key)] = entry
+
+    jobs = []
+
+    for filepath in input_files:
+        filename = os.path.basename(filepath)
+        entry = manifest_map.get(filename, {})
+
+        output_name = entry.get("output")
+        if not output_name:
+            stem, ext = os.path.splitext(filename)
+            output_name = f"{stem}_processed{ext}"
+
+        crop_box = _parse_crop(entry)
+        grading = _extract_grading(entry)
+
+        jobs.append(
+            {
+                "input": filepath,
+                "output": str(output_dir / output_name),
+                "crop_box": crop_box,
+                "grading": grading if grading else None,
+                "target_size": target_size,
+            }
+        )
+
+    return jobs
+
+
+def run_pipeline(
+    input_dir: Path = Path(INPUT_DIR),
+    output_dir: Path = Path(OUTPUT_DIR),
+    target_size: Tuple[int, int] = DCI_4K_RESOLUTION,
+    manifest_path: Optional[Path] = None,
+):
+    input_dir = Path(input_dir)
+    output_dir = Path(output_dir)
+    manifest_path = Path(manifest_path) if manifest_path else input_dir / "manifest.json"
+
+    manifest_entries = load_manifest(manifest_path)
+    jobs = build_jobs(input_dir, output_dir, target_size, manifest_entries)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    processed = []
+    failed = []
+
+    for job in jobs:
+        success = process_image(
+            job["input"],
+            job["output"],
+            target_size=job["target_size"],
+            crop_box=job["crop_box"],
+            grading=job["grading"],
+        )
+        if success:
+            processed.append(job["output"])
+        else:
+            failed.append(job)
+
+    return {
+        "processed": processed,
+        "failed": failed,
+        "jobs": jobs,
+    }
 
 
 def main():
@@ -49,7 +218,7 @@ def main():
     
     # Get all image files from input directory
     input_files = get_image_files(INPUT_DIR)
-    
+
     if not input_files:
         print(f"No image files found in '{INPUT_DIR}' directory.")
         print("Please add some images to process.")
@@ -59,35 +228,28 @@ def main():
     for file in input_files:
         print(f"  - {os.path.basename(file)}")
     
-    # Ensure output directory exists
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
-    
-    # Process each image
-    processed_count = 0
-    failed_count = 0
-    
-    for input_file in input_files:
-        filename = os.path.basename(input_file)
-        name, ext = os.path.splitext(filename)
-        output_file = os.path.join(OUTPUT_DIR, f"{name}_processed{ext}")
-        
-        print(f"Processing: {filename}...")
-        
-        success = process_image(input_file, output_file)
-        
-        if success:
-            processed_count += 1
-            print(f"  ✓ Saved to: {os.path.basename(output_file)}")
-        else:
-            failed_count += 1
-            print(f"  ✗ Failed to process: {filename}")
-    
+    results = run_pipeline(
+        input_dir=Path(INPUT_DIR),
+        output_dir=Path(OUTPUT_DIR),
+        target_size=DCI_4K_RESOLUTION,
+    )
+
+    processed_count = len(results["processed"])
+    failed_count = len(results["failed"])
+
+    for output_path in results["processed"]:
+        print(f"  ✓ Saved to: {os.path.basename(output_path)}")
+
+    for job in results["failed"]:
+        print(f"  ✗ Failed to process: {os.path.basename(job['input'])}")
+
     print(f"\nPipeline completed!")
     print(f"Successfully processed: {processed_count} images")
     if failed_count > 0:
         print(f"Failed to process: {failed_count} images")
-    
-    print(f"Results saved in '{OUTPUT_DIR}' directory.")
+
+    if processed_count:
+        print(f"Results saved in '{OUTPUT_DIR}' directory.")
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -97,10 +97,7 @@ def _extract_grading(entry: Dict) -> Dict[str, float]:
             numeric = float(value)
         except (TypeError, ValueError):
             continue
-        if key in ("micro_contrast", "local_contrast"):
-            grading["micro_contrast"] = numeric
-        else:
-            grading[key] = numeric
+        grading[key] = numeric
 
     return grading
 

--- a/src/processing.py
+++ b/src/processing.py
@@ -11,6 +11,7 @@ import sys
 # Add current directory to path for imports
 sys.path.append(os.path.dirname(__file__))
 from config import DCI_4K_RESOLUTION
+from adjustments import apply_grading
 
 
 def load_image(filepath):
@@ -106,7 +107,13 @@ def resize_image(image, target_size=DCI_4K_RESOLUTION, resample=Image.LANCZOS):
     return background
 
 
-def process_image(input_path, output_path, target_size=DCI_4K_RESOLUTION):
+def process_image(
+    input_path,
+    output_path,
+    target_size=DCI_4K_RESOLUTION,
+    crop_box=None,
+    grading=None,
+):
     """
     Complete image processing workflow: load, resize, and save.
     
@@ -121,10 +128,18 @@ def process_image(input_path, output_path, target_size=DCI_4K_RESOLUTION):
     try:
         # Load the image
         image = load_image(input_path)
-        
-        # Resize to target resolution
-        processed_image = resize_image(image, target_size)
-        
+
+        if crop_box is not None:
+            image = image.crop(tuple(crop_box))
+
+        # Resize to target resolution when requested
+        processed_image = (
+            resize_image(image, target_size) if target_size is not None else image.copy()
+        )
+
+        if grading:
+            processed_image = apply_grading(processed_image, grading)
+
         # Save the processed image
         save_image(processed_image, output_path)
         

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -1,0 +1,88 @@
+"""Tests for grading primitives."""
+
+from pathlib import Path
+import sys
+
+import numpy as np
+from PIL import Image
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.adjustments import (
+    apply_grading,
+    apply_local_contrast,
+    apply_shadow_lift,
+    apply_temperature_shift,
+)
+
+
+def _mean_channels(image: Image.Image):
+    arr = np.asarray(image.convert("RGB"), dtype=np.float32)
+    return arr.mean(axis=(0, 1))
+
+
+def test_temperature_shift_warm_increases_red_channel():
+    original = Image.new("RGB", (32, 32), color=(110, 120, 160))
+
+    warmed = apply_temperature_shift(original, 8.0)
+
+    orig_mean = _mean_channels(original)
+    warm_mean = _mean_channels(warmed)
+
+    assert warm_mean[0] > orig_mean[0]
+    assert warm_mean[2] < orig_mean[2]
+
+
+def test_shadow_lift_brightens_dark_pixels_more_than_midtones():
+    arr = np.zeros((4, 4, 3), dtype=np.uint8)
+    arr[:, :2] = 30
+    arr[:, 2:] = 120
+    image = Image.fromarray(arr, mode="RGB")
+
+    lifted = apply_shadow_lift(image, 0.4)
+    lifted_arr = np.asarray(lifted, dtype=np.uint8)
+
+    assert lifted_arr[:, :2].mean() > arr[:, :2].mean()
+    assert lifted_arr[:, :2].mean() - arr[:, :2].mean() > (
+        lifted_arr[:, 2:].mean() - arr[:, 2:].mean()
+    )
+
+
+def test_local_contrast_increase_raises_standard_deviation():
+    gradient = np.array([
+        [40, 80, 120, 80, 40],
+        [40, 80, 120, 80, 40],
+        [40, 80, 120, 80, 40],
+        [40, 80, 120, 80, 40],
+        [40, 80, 120, 80, 40],
+    ], dtype=np.uint8)
+    image = Image.fromarray(gradient, mode="L").convert("RGB")
+
+    boosted = apply_local_contrast(image, 1.2)
+
+    orig_std = np.asarray(image.convert("L"), dtype=np.float32).std()
+    boosted_std = np.asarray(boosted.convert("L"), dtype=np.float32).std()
+
+    assert boosted_std > orig_std
+
+
+def test_apply_grading_runs_in_order():
+    base = Image.fromarray(np.full((4, 4, 3), 90, dtype=np.uint8), mode="RGB")
+
+    graded = apply_grading(
+        base,
+        {
+            "temperature_shift": 5.0,
+            "shadow_lift": 0.2,
+            "highlight_lift": 0.1,
+            "micro_contrast": 1.1,
+        },
+    )
+
+    graded_mean = _mean_channels(graded)
+    base_mean = _mean_channels(base)
+
+    assert graded_mean[0] >= base_mean[0]
+    assert graded_mean.mean() >= base_mean.mean()

--- a/tests/test_pipeline_manifest.py
+++ b/tests/test_pipeline_manifest.py
@@ -1,0 +1,62 @@
+"""End-to-end test for manifest driven pipeline."""
+
+from pathlib import Path
+import json
+import sys
+
+import numpy as np
+from PIL import Image
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.main import run_pipeline
+
+
+def test_pipeline_applies_crop_and_grading(tmp_path):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    base = np.zeros((20, 40, 3), dtype=np.uint8)
+    base[:, :20] = (30, 60, 180)
+    base[:, 20:] = (180, 90, 30)
+    image = Image.fromarray(base, mode="RGB")
+    source_path = input_dir / "scene.png"
+    image.save(source_path)
+
+    manifest = {
+        "images": [
+            {
+                "file": "scene.png",
+                "crop": [20, 0, 40, 20],
+                "warm_shift": "+6_mireds",
+                "shadow_lift": 0.25,
+                "micro_contrast": 1.1,
+            }
+        ]
+    }
+    manifest_path = input_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    run_pipeline(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        target_size=(20, 20),
+        manifest_path=manifest_path,
+    )
+
+    output_path = output_dir / "scene_processed.png"
+    assert output_path.exists()
+
+    processed = Image.open(output_path)
+    arr = np.asarray(processed.convert("RGB"), dtype=np.float32)
+
+    mean_channels = arr.mean(axis=(0, 1))
+
+    # Cropping should remove the cool half, leaving a warm average
+    assert mean_channels[0] > mean_channels[2]
+    # Shadow lift combined with resizing should raise overall brightness
+    assert mean_channels.mean() > base[:, 20:, :].mean()


### PR DESCRIPTION
## Summary
- add grading helpers for temperature shift, shadow/highlight lift, and local contrast adjustments
- extend the main pipeline to parse manifest metadata for cropping and grading before processing
- add focused unit tests for grading primitives plus an end-to-end manifest-driven regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da670c2494832aa764542f764f5494