### PR TITLE
Add crop presets and integrate variant-aware pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Tools for spatially-aware application of materials and textures to architectural
 ├── input/          # Drop source renderings here
 ├── output/         # Processed images are written here
 ├── src/
-│   ├── config.py   # Central configuration (input/output paths, target resolution)
-│   ├── main.py     # Entry point for batch processing
-│   └── processing.py  # Image processing utilities
+│   ├── adjustments.py  # Crop presets and focal-aware helpers
+│   ├── config.py       # Central configuration (input/output paths, target resolution)
+│   ├── main.py         # Entry point for batch processing
+│   └── processing.py   # Image processing utilities
 └── tests/
     └── test_processing.py  # Unit tests
 ```
@@ -40,6 +41,40 @@ Tools for spatially-aware application of materials and textures to architectural
    ```
 
 3. Processed files will be saved in the `output/` directory with the suffix `_processed`.
+
+### Crop Presets
+
+The `src/adjustments.py` module provides reusable crop helpers that normalize an
+image to a specific aspect ratio before resizing. Each preset accepts an
+optional focal-point offset `(x, y)` in the range `[-1, 1]` to bias the crop
+window towards the top/left (`-1`) or bottom/right (`+1`).
+
+| Preset        | Aspect | Usage notes                                   |
+| ------------- | ------ | --------------------------------------------- |
+| `hero_21x9`   | 21:9   | Wide cinematic hero frames and marquee shots. |
+| `web_16x9`    | 16:9   | General web embeds and responsive hero areas. |
+| `card_4x3`    | 4:3    | Gallery cards and compact thumbnails.         |
+| `square_1x1`  | 1:1    | Balanced social and avatar crops.            |
+
+To incorporate a crop into the processing pipeline, pass a `variant` mapping to
+`process_image`:
+
+```python
+from src.processing import process_image
+
+process_image(
+    "input/render.png",
+    "output/render_hero.png",
+    target_size=(1600, 900),
+    variant={
+        "crop": {"preset": "hero_21x9", "offset": (0, -0.5)},
+        "size": (1600, 900),
+    },
+)
+```
+
+Cropping occurs before letterboxing so the focal composition is maintained while
+still matching the requested output resolution.
 
 ## Running Tests
 

--- a/src/adjustments.py
+++ b/src/adjustments.py
@@ -1,0 +1,151 @@
+"""Image adjustment helpers for cropping architectural renderings.
+
+Provides a set of named crop presets (``hero_21x9``, ``card_4x3``,
+``web_16x9``) that normalize an image to a desired aspect ratio while
+optionally biasing the crop around a focal point.  The presets can be used
+individually or looked up dynamically via :func:`apply_crop_preset`.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
+from PIL import Image
+
+# Public mapping of preset names to their target aspect ratios.
+CROP_PRESETS: Dict[str, Tuple[int, int]] = {
+    "hero_21x9": (21, 9),
+    "card_4x3": (4, 3),
+    "web_16x9": (16, 9),
+    "square_1x1": (1, 1),
+}
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    """Clamp *value* between *minimum* and *maximum*."""
+
+    return max(minimum, min(maximum, value))
+
+
+def _normalize_offset(offset: Iterable[float] | None) -> Tuple[float, float]:
+    """Return a validated ``(x, y)`` focal offset in the range ``[-1, 1]``."""
+
+    if offset is None:
+        return (0.0, 0.0)
+
+    x, y = offset
+    return (_clamp(float(x), -1.0, 1.0), _clamp(float(y), -1.0, 1.0))
+
+
+def _crop_box(
+    original: Tuple[int, int],
+    target_ratio: float,
+    offset: Tuple[float, float],
+) -> Tuple[int, int, int, int]:
+    """Compute a crop box for *original* dimensions and *target_ratio*.
+
+    The offset is expressed in the normalized range ``[-1, 1]`` where ``0`` is
+    center, ``-1`` biases towards the top/left edge, and ``+1`` biases towards
+    the bottom/right edge.
+    """
+
+    width, height = original
+    if width == 0 or height == 0:
+        return (0, 0, width, height)
+
+    current_ratio = width / height
+
+    if abs(current_ratio - target_ratio) < 1e-6:
+        return (0, 0, width, height)
+
+    if current_ratio > target_ratio:
+        # Image is too wide -> trim the sides.
+        new_width = int(round(height * target_ratio))
+        new_height = height
+        available = width - new_width
+        offset_x = (offset[0] + 1.0) / 2.0
+        left = int(round(available * offset_x))
+        left = max(0, min(width - new_width, left))
+        return (left, 0, left + new_width, new_height)
+
+    # Image is too tall -> trim top/bottom.
+    new_width = width
+    new_height = int(round(width / target_ratio))
+    available = height - new_height
+    offset_y = (offset[1] + 1.0) / 2.0
+    top = int(round(available * offset_y))
+    top = max(0, min(height - new_height, top))
+    return (0, top, new_width, top + new_height)
+
+
+def crop_to_aspect(
+    image: Image.Image, aspect: Tuple[int, int], offset: Iterable[float] | None = None
+) -> Image.Image:
+    """Crop *image* to the supplied aspect ratio.
+
+    Args:
+        image: Source PIL image to crop.
+        aspect: ``(width, height)`` tuple describing the target ratio.
+        offset: Optional ``(x, y)`` focal offset within ``[-1, 1]`` to bias the
+            crop window. ``(-1, -1)`` keeps the top-left corner, ``(1, 1)`` keeps
+            the bottom-right corner. Values outside the valid range are clamped.
+
+    Returns:
+        ``Image.Image``: A new image cropped to the requested aspect ratio.
+    """
+
+    target_ratio = aspect[0] / aspect[1]
+    normalized_offset = _normalize_offset(offset)
+    left, top, right, bottom = _crop_box(image.size, target_ratio, normalized_offset)
+    return image.crop((left, top, right, bottom))
+
+
+def apply_crop_preset(
+    image: Image.Image,
+    preset: str,
+    *,
+    offset: Iterable[float] | None = None,
+) -> Image.Image:
+    """Apply the named crop *preset* to *image*.
+
+    Args:
+        image: Source image to crop.
+        preset: Key from :data:`CROP_PRESETS` (e.g., ``"hero_21x9"``).
+        offset: Optional ``(x, y)`` focal offset.
+
+    Raises:
+        KeyError: If the preset name is not recognized.
+    """
+
+    if preset not in CROP_PRESETS:
+        raise KeyError(f"Unknown crop preset: {preset}")
+
+    return crop_to_aspect(image, CROP_PRESETS[preset], offset=offset)
+
+
+def hero_21x9(image: Image.Image, offset: Iterable[float] | None = None) -> Image.Image:
+    """Crop *image* to a cinematic 21:9 hero frame."""
+
+    return crop_to_aspect(image, CROP_PRESETS["hero_21x9"], offset=offset)
+
+
+def card_4x3(image: Image.Image, offset: Iterable[float] | None = None) -> Image.Image:
+    """Crop *image* to a 4:3 ratio suitable for gallery cards."""
+
+    return crop_to_aspect(image, CROP_PRESETS["card_4x3"], offset=offset)
+
+
+def web_16x9(image: Image.Image, offset: Iterable[float] | None = None) -> Image.Image:
+    """Crop *image* to the ubiquitous 16:9 web-safe aspect."""
+
+    return crop_to_aspect(image, CROP_PRESETS["web_16x9"], offset=offset)
+
+
+__all__ = [
+    "CROP_PRESETS",
+    "apply_crop_preset",
+    "card_4x3",
+    "crop_to_aspect",
+    "hero_21x9",
+    "web_16x9",
+]

--- a/src/processing.py
+++ b/src/processing.py
@@ -124,16 +124,18 @@ def _apply_variant_crop(image: Image.Image, variant: Dict) -> Image.Image:
     if not crop_config:
         return image
 
-    offset: Optional[Iterable[float]] = variant.get("crop_offset")
-
     if isinstance(crop_config, str):
+        offset: Optional[Iterable[float]] = variant.get("crop_offset")
         return apply_crop_preset(image, crop_config, offset=offset)
 
     if isinstance(crop_config, dict):
         preset = crop_config.get("preset")
         if not preset:
             raise ValueError("Variant crop dictionaries must include a 'preset' key.")
-        local_offset = crop_config.get("offset", offset)
+        if "offset" in crop_config:
+            local_offset = crop_config["offset"]
+        else:
+            local_offset = variant.get("crop_offset")
         return apply_crop_preset(image, preset, offset=local_offset)
 
     raise TypeError(

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import sys
 
+import pytest
 from PIL import Image, ImageOps
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -10,7 +11,8 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.config import DCI_4K_RESOLUTION
-from src.processing import resize_image
+from src.adjustments import apply_crop_preset, hero_21x9
+from src.processing import process_image, resize_image
 
 
 def test_resize_image_preserves_aspect_ratio_with_padding():
@@ -42,3 +44,64 @@ def test_resize_image_returns_copy_for_matching_dimensions():
     assert resized.size == DCI_4K_RESOLUTION
     assert resized is not original
     assert resized.tobytes() == original.tobytes()
+
+
+def test_hero_crop_produces_expected_ratio():
+    """The 21:9 preset trims the source image while preserving focal offsets."""
+
+    base = Image.new("RGB", (3000, 2000), color=(0, 0, 255))
+    warm_band = Image.new("RGB", (3000, 800), color=(255, 0, 0))
+    base.paste(warm_band, (0, 0))
+
+    cropped_center = hero_21x9(base)
+    cropped_top = hero_21x9(base, offset=(0, -1))
+    cropped_bottom = hero_21x9(base, offset=(0, 1))
+
+    assert cropped_center.width / cropped_center.height == pytest.approx(21 / 9, rel=1e-3)
+    assert cropped_center.size == cropped_top.size == cropped_bottom.size
+
+    # Focal offsets bias which band remains in frame.
+    top_sample = cropped_top.getpixel((cropped_top.width // 2, 10))
+    bottom_sample = cropped_bottom.getpixel((cropped_bottom.width // 2, cropped_bottom.height - 10))
+
+    assert top_sample == (255, 0, 0)
+    assert bottom_sample == (0, 0, 255)
+
+
+def test_apply_crop_preset_resolves_mapping():
+    """Dictionary-based crop declarations are respected."""
+
+    base = Image.new("RGB", (1600, 1600), color=(100, 100, 100))
+    preset_image = apply_crop_preset(base, "web_16x9")
+
+    assert abs((preset_image.width / preset_image.height) - (16 / 9)) < 1e-6
+
+
+def test_process_image_honors_variant_crop(tmp_path):
+    """Crops are performed before resizing so padding only happens afterward."""
+
+    source = Image.new("RGB", (2400, 1600), color=(0, 0, 255))
+    top_band = Image.new("RGB", (2400, 400), color=(255, 0, 0))
+    source.paste(top_band, (0, 0))
+
+    source_path = tmp_path / "source.png"
+    output_path = tmp_path / "variant.png"
+    source.save(source_path)
+
+    variant = {"crop": {"preset": "web_16x9", "offset": (0, -1)}, "size": (1600, 900)}
+
+    success = process_image(
+        str(source_path),
+        str(output_path),
+        target_size=(1600, 900),
+        variant=variant,
+    )
+
+    assert success
+
+    processed = Image.open(output_path)
+    assert processed.size == (1600, 900)
+
+    # Because the variant biases the crop upward, the warm band should still be visible near the top.
+    sample = processed.getpixel((processed.width // 2, 10))
+    assert sample == (255, 0, 0)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -74,7 +74,7 @@ def test_apply_crop_preset_resolves_mapping():
     base = Image.new("RGB", (1600, 1600), color=(100, 100, 100))
     preset_image = apply_crop_preset(base, "web_16x9")
 
-    assert abs((preset_image.width / preset_image.height) - (16 / 9)) < 1e-6
+    assert (preset_image.width / preset_image.height) == pytest.approx(16 / 9, rel=1e-3)
 
 
 def test_process_image_honors_variant_crop(tmp_path):


### PR DESCRIPTION
## Summary
- add an adjustments module with named crop presets and focal offsets
- invoke crop presets from the processing pipeline when variants request them
- document the presets and cover them with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da6708d088832abb4404afc5b2e2d8