### PR TITLE
Refine pipeline to use manifest-driven variants

### DIFF
--- a/config/view_selects.yml
+++ b/config/view_selects.yml
@@ -1,0 +1,34 @@
+# Example manifest describing how source renders should be processed.
+# Each entry under `renders` maps a source image to one or more variants.
+# Variants reference aspect ratio presets defined in src.config.ASPECT_RATIO_PRESETS
+# and can chain multiple operations such as resizing and grading.
+renders:
+  - source: lobby_daylight.jpg
+    variants:
+      - filename: lobby_daylight_dci4k.jpg
+        operations:
+          - type: resize
+            preset: dci_4k
+          - type: grade
+            exposure: 0.05
+            contrast: 1.05
+            saturation: 1.02
+      - filename: lobby_daylight_square.jpg
+        operations:
+          - type: resize
+            preset: square_1080
+          - type: grade
+            exposure: 0.1
+  - source: rooftop_evening.png
+    variants:
+      - filename: rooftop_evening_story.png
+        operations:
+          - type: resize
+            preset: vertical_story
+          - type: grade
+            exposure: -0.05
+            saturation: 1.1
+      - filename: rooftop_evening_ultrawide.png
+        operations:
+          - type: resize
+            preset: ultrawide

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Pillow
 opencv-python
+PyYAML

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,7 @@
-"""
-Configuration constants for the rendering pipeline.
-Defines project-wide settings and constants.
-"""
+"""Project-wide configuration constants for the rendering pipeline."""
+
+from pathlib import Path
+
 
 # 4K DCI (Digital Cinema Initiative) resolution
 DCI_4K_WIDTH = 4096
@@ -11,3 +11,15 @@ DCI_4K_RESOLUTION = (DCI_4K_WIDTH, DCI_4K_HEIGHT)
 # Directory paths
 INPUT_DIR = "input"
 OUTPUT_DIR = "output"
+
+# Default manifest describing rendering tasks
+DEFAULT_MANIFEST_PATH = Path("config") / "view_selects.yml"
+
+
+# Common aspect ratio presets that can be referenced from the manifest.
+ASPECT_RATIO_PRESETS = {
+    "dci_4k": DCI_4K_RESOLUTION,
+    "square_1080": (1080, 1080),
+    "vertical_story": (1080, 1920),
+    "ultrawide": (5120, 2160),
+}

--- a/src/main.py
+++ b/src/main.py
@@ -1,94 +1,158 @@
-"""
-Main pipeline for processing architectural renderings.
-Iterates through images in the input directory, applies processing,
-and saves results to the output directory.
-"""
+"""CLI entry point that drives the rendering pipeline via a YAML manifest."""
 
+import argparse
 import os
 import sys
 from pathlib import Path
+from typing import Dict, Iterable, List
+
+import yaml
 
 # Add src directory to path so we can import our modules
 sys.path.append(os.path.join(os.path.dirname(__file__)))
 
-from processing import process_image
-from config import INPUT_DIR, OUTPUT_DIR, DCI_4K_RESOLUTION
+from config import (
+    ASPECT_RATIO_PRESETS,
+    DEFAULT_MANIFEST_PATH,
+    INPUT_DIR,
+    OUTPUT_DIR,
+)
+from processing import process_variant
 
 
-def get_image_files(directory):
-    """
-    Get list of image files from the specified directory.
-    
-    Args:
-        directory (str): Directory path to scan for images
-        
-    Returns:
-        list: List of image file paths
-    """
-    image_extensions = {'.jpg', '.jpeg', '.png', '.bmp', '.tiff', '.tif'}
-    image_files = []
-    
-    if not os.path.exists(directory):
-        print(f"Input directory '{directory}' does not exist.")
-        return image_files
-    
-    for file in os.listdir(directory):
-        if any(file.lower().endswith(ext) for ext in image_extensions):
-            image_files.append(os.path.join(directory, file))
-    
-    return sorted(image_files)
+def _coerce_path(path_str: str, base: Path) -> Path:
+    """Return ``path_str`` as a :class:`~pathlib.Path` relative to ``base``."""
+
+    path = Path(path_str)
+    if not path.is_absolute():
+        path = base / path
+    return path
 
 
-def main():
-    """
-    Main pipeline execution.
-    Processes all images in the input directory and saves them to the output directory.
-    """
-    print("Starting rendering pipeline...")
-    print(f"Target resolution: {DCI_4K_RESOLUTION[0]}x{DCI_4K_RESOLUTION[1]} (4K DCI)")
-    
-    # Get all image files from input directory
-    input_files = get_image_files(INPUT_DIR)
-    
-    if not input_files:
-        print(f"No image files found in '{INPUT_DIR}' directory.")
-        print("Please add some images to process.")
-        return
-    
-    print(f"Found {len(input_files)} image(s) to process:")
-    for file in input_files:
-        print(f"  - {os.path.basename(file)}")
-    
-    # Ensure output directory exists
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
-    
-    # Process each image
-    processed_count = 0
-    failed_count = 0
-    
-    for input_file in input_files:
-        filename = os.path.basename(input_file)
-        name, ext = os.path.splitext(filename)
-        output_file = os.path.join(OUTPUT_DIR, f"{name}_processed{ext}")
-        
-        print(f"Processing: {filename}...")
-        
-        success = process_image(input_file, output_file)
-        
+def load_manifest(manifest_path: Path) -> Dict:
+    """Load and validate the YAML manifest located at ``manifest_path``."""
+
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest file not found: {manifest_path}")
+
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+
+    renders = data.get("renders")
+    if not isinstance(renders, list) or not renders:
+        raise ValueError("Manifest must define a non-empty 'renders' list.")
+
+    return data
+
+
+def iterate_tasks(
+    manifest: Dict,
+    input_dir: Path,
+    output_dir: Path,
+) -> Iterable[Dict]:
+    """Yield processing tasks described by ``manifest``."""
+
+    for render in manifest.get("renders", []):
+        source = render.get("source")
+        if not source:
+            raise ValueError("Each render entry requires a 'source' value.")
+
+        source_path = _coerce_path(source, input_dir)
+        variants = render.get("variants") or []
+
+        if not variants:
+            raise ValueError(f"Render '{source}' defines no variants.")
+
+        for variant in variants:
+            filename = variant.get("filename") or variant.get("name")
+            if not filename:
+                raise ValueError(
+                    f"Variant for '{source}' must include a 'filename'."
+                )
+
+            operations: List[Dict] = variant.get("operations") or []
+            output_subdir = variant.get("directory")
+
+            if output_subdir:
+                target_dir = _coerce_path(output_subdir, output_dir)
+            else:
+                target_dir = output_dir
+
+            yield {
+                "source": source_path,
+                "output": target_dir / filename,
+                "operations": operations,
+            }
+
+
+def main(argv: List[str] | None = None) -> int:
+    """Entry point used by both the CLI and tests."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        default=str(DEFAULT_MANIFEST_PATH),
+        help="Path to the YAML manifest that describes processing tasks.",
+    )
+    parser.add_argument(
+        "--input-dir",
+        default=str(INPUT_DIR),
+        help="Base directory used to resolve relative source paths.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(OUTPUT_DIR),
+        help="Directory where processed variants are written.",
+    )
+
+    args = parser.parse_args(argv)
+
+    manifest_path = Path(args.manifest)
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+
+    try:
+        manifest = load_manifest(manifest_path)
+    except (OSError, ValueError) as exc:
+        print(f"Error loading manifest: {exc}")
+        return 1
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    tasks = list(iterate_tasks(manifest, input_dir, output_dir))
+    print(f"Loaded {len(tasks)} variant task(s) from {manifest_path}.")
+
+    processed = 0
+    failed = 0
+
+    for task in tasks:
+        source = task["source"]
+        output_path = task["output"]
+        operations = task["operations"]
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        print(f"Processing {source.name} -> {output_path.name}...")
+
+        success = process_variant(
+            str(source),
+            str(output_path),
+            operations,
+            presets=ASPECT_RATIO_PRESETS,
+        )
+
         if success:
-            processed_count += 1
-            print(f"  ✓ Saved to: {os.path.basename(output_file)}")
+            processed += 1
+            print(f"  ✓ Saved to {output_path}")
         else:
-            failed_count += 1
-            print(f"  ✗ Failed to process: {filename}")
-    
-    print(f"\nPipeline completed!")
-    print(f"Successfully processed: {processed_count} images")
-    if failed_count > 0:
-        print(f"Failed to process: {failed_count} images")
-    
-    print(f"Results saved in '{OUTPUT_DIR}' directory.")
+            failed += 1
+            print(f"  ✗ Failed to process {source}")
+
+    print(
+        f"Completed processing: {processed} succeeded, {failed} failed."
+    )
+
+    return 0 if failed == 0 else 2
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,8 +1,10 @@
-"""Tests for the image processing utilities."""
+"""Tests for the image processing utilities and CLI integration."""
 
-from pathlib import Path
+import subprocess
 import sys
+from pathlib import Path
 
+import yaml
 from PIL import Image, ImageOps
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -42,3 +44,77 @@ def test_resize_image_returns_copy_for_matching_dimensions():
     assert resized.size == DCI_4K_RESOLUTION
     assert resized is not original
     assert resized.tobytes() == original.tobytes()
+
+
+def test_cli_processes_manifest_and_creates_variants(tmp_path):
+    """The CLI loads a manifest and emits the declared output variants."""
+
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    base_image = Image.new("RGB", (800, 600), color=(100, 100, 100))
+    source_path = input_dir / "test_render.jpg"
+    base_image.save(source_path)
+
+    manifest = {
+        "renders": [
+            {
+                "source": "test_render.jpg",
+                "variants": [
+                    {
+                        "filename": "test_render_square.jpg",
+                        "operations": [
+                            {"type": "grade", "exposure": 0.2},
+                            {"type": "resize", "preset": "square_1080"},
+                        ],
+                    },
+                    {
+                        "filename": "test_render_custom.jpg",
+                        "operations": [
+                            {"type": "resize", "width": 640, "height": 360},
+                            {"type": "grade", "contrast": 0.5},
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+
+    manifest_path = tmp_path / "manifest.yml"
+    manifest_path.write_text(yaml.safe_dump(manifest))
+
+    # Exercise the CLI entry point using a subprocess to mimic real usage.
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.main",
+            "--manifest",
+            str(manifest_path),
+            "--input-dir",
+            str(input_dir),
+            "--output-dir",
+            str(output_dir),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    square_output = output_dir / "test_render_square.jpg"
+    custom_output = output_dir / "test_render_custom.jpg"
+
+    assert square_output.exists(), completed.stdout
+    assert custom_output.exists(), completed.stdout
+
+    square_image = Image.open(square_output)
+    assert square_image.size == (1080, 1080)
+
+    # The center pixel should be brightened compared to the source (100 -> 120).
+    center_pixel = square_image.getpixel((square_image.width // 2, square_image.height // 2))
+    assert center_pixel[0] >= 118
+
+    custom_image = Image.open(custom_output)
+    assert custom_image.size == (640, 360)


### PR DESCRIPTION
## Summary
- introduce a YAML manifest that maps renders to named variant outputs and operations
- update the CLI to load the manifest, resolve presets, and run ordered variant operations
- extend processing utilities to chain resize/grade steps and add integration tests through the CLI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da67026fe8832a858404ac96b3ea5a