### PR TITLE
Support multiplicative grading values for contrast and saturation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,16 @@ python -m src.main --manifest config/view_selects.yml --input-dir input --output
 The YAML manifest allows you to specify:
 - Multiple output variants per source image
 - Crop operations using preset aspect ratios with focal offsets
-- Resize operations with aspect ratio presets  
+- Resize operations with aspect ratio presets
 - Color grading operations (exposure, contrast, saturation, temperature_shift, shadow_lift, highlight_lift, micro_contrast)
 - Custom output filenames and directories
+
+Contrast and saturation grading entries accept either multiplier-style values
+(`1.35` increases contrast by 35%) or legacy additive deltas in the range
+`[-1.0, 1.0]` which are converted to multipliers internally (for example,
+`0.2` becomes `1.2`). Use values greater than `1.0` to take direct control over
+the enhancement factor in new manifests while continuing to support older
+configurations.
 
 Example YAML manifest with crop and advanced grading:
 


### PR DESCRIPTION
## Summary
- allow manifest contrast and saturation grading values to act as direct multipliers while keeping legacy additive support
- extend processing tests to cover both additive-style and multiplier-style grading inputs
- document the dual contrast/saturation semantics in the manifest guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db38d1e8b4832a97be71efc15917a4