### PR TITLE
Support positional directory overrides for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ Tools for spatially-aware application of materials and textures to architectural
 
 3. Processed files will be saved in the `results/new_output/` directory with the suffix `_processed`.
 
+To quickly process a different folder without editing configuration files, you can
+pass the directories as positional arguments. The first path overrides the input
+directory and an optional second path overrides the output directory:
+
+```bash
+python -m src.main /path/to/input /path/to/output
+```
+
+When using the legacy JSON pipeline, combine the positional overrides with the
+`--legacy` flag:
+
+```bash
+python -m src.main --legacy /path/to/input /path/to/output
+```
+
 ### YAML Manifest Processing
 
 For advanced workflows, you can use YAML manifests to define multiple variants and operations:

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -38,19 +38,82 @@ def test_main_legacy_flag_invokes_legacy(monkeypatch):
     """The --legacy flag should route execution through the legacy pipeline."""
 
     run_called = False
+    captured = {}
 
     def fake_run_yaml(*_args, **_kwargs):  # pragma: no cover - should be skipped
         nonlocal run_called
         run_called = True
         return 0
 
-    def fake_legacy():
+    def fake_legacy(*, input_dir, output_dir, target_size):
+        captured["args"] = (input_dir, output_dir, target_size)
         return 5
 
     monkeypatch.setattr(cli, "run_yaml_pipeline", fake_run_yaml)
     monkeypatch.setattr(cli, "main_legacy", fake_legacy)
 
-    exit_code = cli.main(["--legacy"])
+    exit_code = cli.main(["--legacy", "--input-dir", "custom/in", "--output-dir", "custom/out"])
 
     assert exit_code == 5
     assert run_called is False
+
+    input_dir, output_dir, target_size = captured["args"]
+    assert input_dir == Path("custom/in")
+    assert output_dir == Path("custom/out")
+    assert target_size == cli.DCI_4K_RESOLUTION
+
+
+def test_main_accepts_positional_input_override(monkeypatch, tmp_path):
+    """Providing a single positional path should override the input directory."""
+
+    captured = {}
+
+    def fake_run_yaml(manifest_path, input_dir, output_dir):
+        captured["args"] = (manifest_path, input_dir, output_dir)
+        return 0
+
+    def fail_legacy(*_args, **_kwargs):  # pragma: no cover - should not run
+        raise AssertionError("Legacy path should not execute when --legacy is absent")
+
+    monkeypatch.setattr(cli, "run_yaml_pipeline", fake_run_yaml)
+    monkeypatch.setattr(cli, "main_legacy", fail_legacy)
+
+    custom_input = tmp_path / "assets"
+
+    exit_code = cli.main([str(custom_input)])
+
+    assert exit_code == 0
+    _, input_dir, output_dir = captured["args"]
+    assert input_dir == custom_input
+    assert output_dir == Path("results/new_output")
+
+
+def test_main_accepts_positional_input_and_output_for_legacy(monkeypatch, tmp_path):
+    """Two positional paths should override input and output for the legacy pipeline."""
+
+    captured = {}
+
+    def fake_run_yaml(*_args, **_kwargs):  # pragma: no cover - skip YAML path
+        raise AssertionError("YAML pipeline should not run when --legacy is provided")
+
+    def fake_legacy(*, input_dir, output_dir, target_size):
+        captured["args"] = (input_dir, output_dir, target_size)
+        return 0
+
+    monkeypatch.setattr(cli, "run_yaml_pipeline", fake_run_yaml)
+    monkeypatch.setattr(cli, "main_legacy", fake_legacy)
+
+    custom_input = tmp_path / "assets"
+    custom_output = tmp_path / "processed"
+
+    exit_code = cli.main([
+        "--legacy",
+        str(custom_input),
+        str(custom_output),
+    ])
+
+    assert exit_code == 0
+    input_dir, output_dir, target_size = captured["args"]
+    assert input_dir == custom_input
+    assert output_dir == custom_output
+    assert target_size == cli.DCI_4K_RESOLUTION


### PR DESCRIPTION
## Summary
- allow the CLI to accept positional arguments that override the input/output directories
- validate mixed positional and flag-based overrides to avoid ambiguity
- document the new shorthand in the README and add tests covering the behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db60bd512c832a8c09a813ceec2c16