### PR TITLE
Add masked inpainting and material enhancement operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The YAML manifest allows you to specify:
 - Crop operations using preset aspect ratios with focal offsets
 - Resize operations with aspect ratio presets
 - Color grading operations (exposure, contrast, saturation, temperature_shift, shadow_lift, highlight_lift, micro_contrast)
+- Mask-driven inpainting to remove furnishings or signage (`type: inpaint`)
+- Material enrichment operations to emphasize texture and surface clarity (`type: material_enhance`)
 - Custom output filenames and directories
 
 Contrast and saturation grading entries accept either multiplier-style values
@@ -95,6 +97,17 @@ renders:
           - type: grade
             temperature_shift: 15  # Warm the image
             micro_contrast: 1.1    # Enhance local contrast
+      - filename: lobby_daylight_clean.jpg
+        operations:
+          - type: inpaint
+            mask: masks/lobby_daylight_furniture.png  # remove stools and accent tables
+            blur_radius: 18
+            feather_radius: 6
+          - type: material_enhance
+            clarity: 1.25
+            micro_contrast: 1.3
+            depth: 1.1
+            sheen: 1.05
 ```
 
 ### Crop Presets

--- a/config/view_selects.yml
+++ b/config/view_selects.yml
@@ -29,6 +29,18 @@ renders:
           - type: grade
             temperature_shift: 15  # Warm the image slightly
             micro_contrast: 1.1    # Enhance local contrast
+      - filename: lobby_daylight_clean.jpg
+        directory: clean
+        operations:
+          - type: inpaint
+            mask: masks/lobby_daylight_furniture.png
+            blur_radius: 20
+            feather_radius: 6
+          - type: material_enhance
+            clarity: 1.25
+            micro_contrast: 1.3
+            depth: 1.08
+            sheen: 1.04
   - source: rooftop_evening.png
     variants:
       - filename: rooftop_evening_story.png

--- a/tests/test_adjustments.py
+++ b/tests/test_adjustments.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import sys
 
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageDraw
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -15,6 +15,8 @@ from src.adjustments import (
     apply_local_contrast,
     apply_shadow_lift,
     apply_temperature_shift,
+    enhance_material_definition,
+    inpaint_with_mask,
 )
 
 
@@ -86,3 +88,43 @@ def test_apply_grading_runs_in_order():
 
     assert graded_mean[0] >= base_mean[0]
     assert graded_mean.mean() >= base_mean.mean()
+
+
+def test_inpaint_with_mask_softens_marked_region():
+    background_color = (120, 130, 140)
+    image = Image.new("RGB", (80, 80), color=background_color)
+    draw = ImageDraw.Draw(image)
+    draw.rectangle([20, 20, 60, 60], fill=(220, 40, 40))
+
+    mask = Image.new("L", (80, 80), 0)
+    mask_draw = ImageDraw.Draw(mask)
+    mask_draw.rectangle([20, 20, 60, 60], fill=255)
+
+    before = np.asarray(image, dtype=np.int16)
+    target_region_before = before[25:55, 25:55]
+    baseline_diff = np.abs(target_region_before - np.array(background_color)).mean()
+
+    cleaned = inpaint_with_mask(image, mask, blur_radius=12, feather_radius=4)
+    after = np.asarray(cleaned, dtype=np.int16)
+    target_region_after = after[25:55, 25:55]
+    cleaned_diff = np.abs(target_region_after - np.array(background_color)).mean()
+
+    assert cleaned_diff < baseline_diff
+
+
+def test_enhance_material_definition_boosts_contrast():
+    gradient = np.tile(np.linspace(90, 160, 64, dtype=np.uint8), (64, 1))
+    image = Image.fromarray(gradient, mode="L").convert("RGB")
+
+    enhanced = enhance_material_definition(
+        image,
+        clarity=1.3,
+        micro_contrast=1.4,
+        depth=1.15,
+        sheen=1.05,
+    )
+
+    base_std = np.asarray(image.convert("L"), dtype=np.float32).std()
+    enhanced_std = np.asarray(enhanced.convert("L"), dtype=np.float32).std()
+
+    assert enhanced_std > base_std


### PR DESCRIPTION
## Summary
- introduce masked inpainting and material enhancement helpers to target furniture removal and richer surfaces
- extend the processing pipeline and sample manifest to support the new operations
- add unit tests covering the helpers and pipeline integrations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db70d90a98832a8a470c83599d9b6e